### PR TITLE
In Support of Chris Bourg

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ unprofessional behavior.
 * Brad Houston 
 * Eric Hellman
 * May Yan
+* Lisa Martincik
 
 
 *Additional signatures are welcome. To sign, please open a pull request


### PR DESCRIPTION
Chris Bourg of MIT was asked to give a code4lib keynote, delivered swimmingly, and was then unfairly and unseemly harshed. We support Chris Bourg.