### PR TITLE
Adding Canadian Association of Research Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ unprofessional behavior.
 * Association of University Presses
 * Black Caucus of the American Library Association (BCALA)
 * Boston Library Consortium
+* Canadian Association of Research Libraries – Association des bibliothèques de recherche du Canada
 * Council on Library and Information Resources (CLIR)
 * Data Curation Experts, LLC (DCE)
 * Digital Frontiers


### PR DESCRIPTION
Adding Canadian Association of Research Libraries – Association des bibliothèques de recherche du Canada per request:

Hello Margaret,

Donna has kindly offered your services to help us add “Canadian Association of Research Libraries – Association des bibliothèques de recherche du Canada” to the institutional signatories listed on the statement in support of Chris Bourg (https://code4lib.github.io/c4l18-keynote-statement/). Would you mind helping us out with this? 

Many thanks,
Lise

-- 
Lise Brin, MLIS
Program Officer / Agente de programme

 
 
Canadian Association of Research Libraries
Association des bibliothèques de recherche du Canada
309 rue Cooper Street, Suite 203
Ottawa Ontario K2P 0G5
T    902.318.4485
E    lise.brin@carl-abrc.ca 
W   www.carl-abrc.ca
 @carlabrc